### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Bug fixes
 
-- Add export for Modal component ()
-- Add to prop type for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ()
-- Fix text underline for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ()
+- Add export for Modal component ([5cfe343](https://github.com/daroucha/remaster-ui/commit/5cfe34387699c4ca3c78869df9872baae67a1605))
+- Add to prop type for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ([20d6eb7](https://github.com/daroucha/remaster-ui/commit/20d6eb7c64168eda26f48dcd286ba537a0844150))
+- Fix text underline for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ([b2ca519](https://github.com/daroucha/remaster-ui/commit/b2ca5191c1b8ba06c3a7b7bc25ff72823c8fef3b))
 
 ### Features
 
-- ProgressBar now absorves the color of the parent wrapper ()
+- ProgressBar now absorves the color of the parent wrapper ([58d4c5f](https://github.com/daroucha/remaster-ui/commit/58d4c5f493df80439857473e40f0132fcc49926a))
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.1
+
+### Bug fixes
+
+- Add export for Modal component ()
+
+### Features
+
+- ProgressBar now absorves the color of the parent wrapper ()
+
 ## 1.1.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Add export for Modal component ()
+- Add to prop type for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ()
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add export for Modal component ()
 - Add to prop type for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ()
+- Fix text underline for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ()
 
 ### Features
 

--- a/src/components/ActionButton/action-button.tsx
+++ b/src/components/ActionButton/action-button.tsx
@@ -31,6 +31,7 @@ interface PropsActionButton
   size: 'small' | 'medium'
   text: string
   type?: string
+  to?: string
   trailing?: React.ReactNode
   variant: 'primary' | 'secondary' | 'tertiary'
 }

--- a/src/components/ActionButton/styled-button-base.tsx
+++ b/src/components/ActionButton/styled-button-base.tsx
@@ -19,6 +19,7 @@ const StyledButtonBase = styled.button<{ disabled: boolean }>`
   padding-block: ${$space.block.sm};
   padding-inline: ${$space.inline.md};
   position: relative;
+  text-decoration: none;
 `
 
 const ButtonIconBase = styled.div<{ $loading?: boolean }>`

--- a/src/components/Dropdown/dropdown-menu.tsx
+++ b/src/components/Dropdown/dropdown-menu.tsx
@@ -58,6 +58,7 @@ function DropdownItem({
   title,
   text,
   trailing,
+  ...restProps
 }: PropsMenuItem) {
   const { setVisibility } = useDropdownContext()
 
@@ -77,6 +78,7 @@ function DropdownItem({
       title={title}
       text={text}
       trailing={trailing}
+      {...restProps}
     />
   )
 }

--- a/src/components/IconButton/icon-button.tsx
+++ b/src/components/IconButton/icon-button.tsx
@@ -18,6 +18,7 @@ interface PropsIconButton
   onClick?: (event: React.MouseEvent) => void
   size: 'small' | 'medium'
   text?: string
+  to?: string
 }
 
 function IconButton({

--- a/src/components/IconButton/styled-icon-button.tsx
+++ b/src/components/IconButton/styled-icon-button.tsx
@@ -29,6 +29,7 @@ const StyledIconButton = styled.button<{
   opacity: ${(props) => (props.disabled ? '60%' : '100%')};
   padding-block: ${$space.inline.xs};
   padding-inline: ${$space.inline.sm};
+  text-decoration: none;
 
   &:hover:not(:disabled) {
     background: ${(props) =>

--- a/src/components/Link/link.tsx
+++ b/src/components/Link/link.tsx
@@ -12,11 +12,13 @@ type PolymorphicAsProp<E extends React.ElementType> = {
 
 interface PropsLink extends PolymorphicAsProp<React.ElementType> {
   children: string | React.ReactNode
+  className?: string
   disabled?: boolean
   href?: string
   leading?: React.ReactNode
   onClick?: () => void
   size: 'small' | 'medium'
+  to?: string
   trailing?: boolean
 }
 

--- a/src/components/Menu/menu-item.tsx
+++ b/src/components/Menu/menu-item.tsx
@@ -22,8 +22,9 @@ interface PropsMenuItem extends PolymorphicAsProp<React.ElementType> {
   divider?: boolean
   leading?: React.ReactNode
   onClick?: () => void
-  title: string
   text?: string
+  title: string
+  to?: string
   trailing?: React.ReactNode | string
 }
 

--- a/src/components/Menu/styled-menu.tsx
+++ b/src/components/Menu/styled-menu.tsx
@@ -46,6 +46,7 @@ const StyledMenuItem = styled.div<{ $disabled?: boolean }>`
   display: block;
   flex-direction: column;
   position: relative;
+  text-decoration: none;
   width: 100%;
   z-index: 3;
 `

--- a/src/components/NavigationLink/navigation-link.tsx
+++ b/src/components/NavigationLink/navigation-link.tsx
@@ -12,12 +12,14 @@ type PolymorphicAsProp<E extends React.ElementType> = {
 interface PropsNavigationLink
   extends PolymorphicAsProp<React.ElementType> {
   active?: boolean
+  className?: string
   disabled?: boolean
   href?: string
   leading?: React.ReactNode
   onClick?: (event: React.MouseEvent) => void
   size: 'small' | 'medium'
   text: string
+  to?: string
   trailing?: React.ReactNode
 }
 

--- a/src/components/NavigationLink/styled-navigation-link.tsx
+++ b/src/components/NavigationLink/styled-navigation-link.tsx
@@ -22,6 +22,7 @@ const StyledNL = styled.a<{
   padding-block: ${$space.block.sm};
   padding-inline: ${(props) =>
     props.$size === 'medium' ? $space.inline.lg : $space.inline.sm};
+  text-decoration: none;
   width: max-content;
 
   &:hover {

--- a/src/components/ProgressBar/styled-progress-bar.tsx
+++ b/src/components/ProgressBar/styled-progress-bar.tsx
@@ -1,11 +1,11 @@
-import { $color, $motion, $primitives, $size } from '@/tokens'
+import { $motion, $primitives, $size } from '@/tokens'
 import styled from '@emotion/styled'
 
 const StyledProgressBar = styled.div<{ $type: string }>`
-  background: ${$color.background.elevation.secondary.light};
   border-radius: ${(props) =>
     props.$type === 'bleed' ? '0px' : $size.radius.md};
   box-sizing: border-box;
+  color: inherit;
   display: inline-block;
   height: ${(props) =>
     props.$type === 'bleed'
@@ -18,17 +18,32 @@ const StyledProgressBar = styled.div<{ $type: string }>`
     props.$type === 'bleed' ? '0px' : $primitives.units['0.5x']};
   padding-inline: ${(props) =>
     props.$type === 'bleed' ? '0px' : $primitives.units['0.5x']};
+
+  &::after {
+    background: currentColor;
+    content: '';
+    display: block;
+    height: 100%;
+    inset: 0px;
+    position: absolute;
+    width: 100%;
+    opacity: 30%;
+    z-index: 1;
+  }
 `
 
 const PBar = styled.div<{ $type: string }>`
-  background: ${$color.background.surface.primary.light};
+  background: currentColor;
   border-radius: ${(props) =>
     props.$type === 'bleed' ? '0px' : $size.radius.md};
+  color: inherit;
   display: block;
   height: 100%;
+  position: relative;
   transition-duration: ${$motion.duration.fast};
   transition-property: width;
   transition-timing-function: ${$motion.curve.linear};
+  z-index: 3;
 `
 
 export { StyledProgressBar, PBar }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { CoverCard } from './CoverCard'
-import { Dialog } from './Dialog'
+import { Dialog, Modal } from './Dialog'
 import ActionButton from './ActionButton'
 import Alert from './Alert'
 import Avatar from './Avatar'
@@ -68,6 +68,7 @@ export {
   Link,
   ListComponent,
   Menu,
+  Modal,
   NavigationLink,
   Paginator,
   PerspectiveCarousel,


### PR DESCRIPTION
## 1.1.1

### Bug fixes

- Add export for Modal component ([5cfe343](https://github.com/daroucha/remaster-ui/commit/5cfe34387699c4ca3c78869df9872baae67a1605))
- Add to prop type for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ([20d6eb7](https://github.com/daroucha/remaster-ui/commit/20d6eb7c64168eda26f48dcd286ba537a0844150))
- Fix text underline for Link, NavigationLink, MenuItem, DropdownMenuItem, ActionButton and IconButton ([b2ca519](https://github.com/daroucha/remaster-ui/commit/b2ca5191c1b8ba06c3a7b7bc25ff72823c8fef3b))

### Features

- ProgressBar now absorves the color of the parent wrapper ([58d4c5f](https://github.com/daroucha/remaster-ui/commit/58d4c5f493df80439857473e40f0132fcc49926a))